### PR TITLE
Rename "Non-Woke Operating Systems" to "Non-Woke Software"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ The following software projects, software foundations, &amp; corporations have m
 | :arrow_left: | **elementaryOS** | [Says talking to Conservatives is "associating with fascists"](https://x.com/LundukeJournal/status/1962669374331895901), [Celebrates Pride Month](https://x.com/LundukeJournal/status/1929024728758403187) |
 | :arrow_left: | **Debian** | [Prominent contributor defaced "Conservative" project wiki, calling them "Nazis"](https://x.com/LundukeJournal/status/1942269768192737511) |
 
-### Non-Woke Operating Systems
+### Non-Woke Software
 
 The following software projects, foundations, &amp; corporations have made statements (or taken actions) best categorized "Non-Woke", or "Right Leaning".


### PR DESCRIPTION
This patch is to match the name for the woke software section.