### PR TITLE
Added Sneedacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ The following software projects, foundations, &amp; corporations have made state
 | :arrow_right: | **Redot** | ["Non-Political (non-Woke) Fork" of Godot](https://x.com/LundukeJournal/status/1842335793844539823) |
 | :arrow_right: | **SQLite** | [Code of Conduct includes "Love the Lord God"](https://x.com/LundukeJournal/status/2029990961988915399) |
 | :arrow_right: | **XLibre** | [Rejects DEI discrimination of Xorg](https://x.com/LundukeJournal/status/1930727192964514137) |
-
+| :arrow_right: | **Sneedacity** | [Brief History of Sneed](https://youtu.be/tUbo0IeWTY4&t=58s) |


### PR DESCRIPTION
Whilst not officially stated in the project's documentation or code of conduct, the act of posting Sneed-related content (i.e. Sneedposting) is widely used on certain imageboards and in right-wing meme lexicon.